### PR TITLE
check output dir exists

### DIFF
--- a/src/pyglottolog/api.py
+++ b/src/pyglottolog/api.py
@@ -174,6 +174,8 @@ class Glottolog(API):
 
     def write_languoids_table(self, outdir, version=None):
         version = version or self.describe()
+        if outdir is not None and not outdir.exists():
+            raise IOError("Specified output directory %s does not exist. Please create it." % outdir)
         out = outdir / 'glottolog-languoids-{0}.csv'.format(version)
         md = outdir / (out.name + '-metadata.json')
         tg = TableGroup.fromvalue({


### PR DESCRIPTION
the `write_languoids_table` command takes an argument `outdir`, which specifies the path to an output directory. If the dir is not present, it fails as the path <outdir> does not exist.

This PR adds a check for a non-existent directory and generates a relevant error (which I thought was less intrusive than creating a directory)