### PR TITLE
remove bs4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
         'newick<=0.9.2; python_version < "3.5"',
         'newick>=0.9.2; python_version >= "3.5"',
         'markdown',
-        'bs4',
         'requests',
         'nameparser',
     ],

--- a/src/pyglottolog/links/util.py
+++ b/src/pyglottolog/links/util.py
@@ -7,7 +7,7 @@ import collections
 from csvw.dsv import reader
 import requests
 from pycldf.dataset import MD_SUFFIX
-from bs4 import BeautifulSoup
+
 
 
 def read_cldf_languages(url):  # pragma: no cover
@@ -81,8 +81,9 @@ class PHOIBLE(LinkProvider):  # pragma: no cover
 
     def __init__(self):
         r = requests.get('https://doi.org/10.5281/zenodo.2562766')
-        html = BeautifulSoup(r.text, 'html.parser')
-        self.__cldf_dataset_url__ = html.find('link', rel='alternate')['href']
+        record_id = r.url.split("/")[-1]
+        r = requests.get('https://zenodo.org/api/records/%s' % record_id)
+        self.__cldf_dataset_url__ = r.json()['files'][0]['links']['self']
 
     def iterupdated(self, languoids):  # pragma: no cover
         urls = {}


### PR DESCRIPTION
While looking over pip freeze, I wondered why pyglottolog installs beautiful soup. It's only used in one place, to scrape the URL for Phoible from Zenodo.

It's probably easier to call the API directly -- ```https://zenodo.org/api/records/2677911```, since _requests_ is a requirement, this makes it easy. This PR does that, but should be checked that I've gotten the correct thing.