### PR TITLE
add iter_descendants

### DIFF
--- a/src/pyglottolog/languoids/languoid.py
+++ b/src/pyglottolog/languoids/languoid.py
@@ -311,6 +311,11 @@ class Languoid(object):
                 # we ignore leading non-languoid-dir path components.
                 break
 
+    def iter_descendants(self):
+        for child in self.children:
+            yield child
+            yield from child.iter_descendants()
+
     @property
     def ancestors(self) -> typing.List['Languoid']:
         """

--- a/tests/test_languoids.py
+++ b/tests/test_languoids.py
@@ -275,3 +275,9 @@ def test_attrs(api):
         l.id = 'x'
     assert l.id == l.glottocode
     assert l.hid == 'NOCODE'
+
+
+def test_iter_descendants(api):
+    children = [l.id for l in api.languoid('abcd1234').iter_descendants()]
+    assert children == ['abcd1235', 'abcd1236']
+    


### PR DESCRIPTION
Adding an iter_descendants method would be helpful -- I keep wanting to get a languoid and then iterate over its children. 